### PR TITLE
Makes invisible characters and wrap guide darker

### DIFF
--- a/index.less
+++ b/index.less
@@ -346,3 +346,11 @@
 .editor .indent-guide {
     color: lighten(#26292C, 10%);
 }
+
+.invisible-character {
+  color: lighten(#26292C, 10%);
+}
+
+.wrap-guide {
+  background-color: lighten(#26292C, 10%);
+}


### PR DESCRIPTION
I found the invisible character and wrap guide way too bright and distracting, this darkens them so text stands out better.

Before
![before](https://cloud.githubusercontent.com/assets/244198/3095983/8fe7f9fe-e5ce-11e3-925d-4fcf77d73bed.png)

After
![after](https://cloud.githubusercontent.com/assets/244198/3095984/916d51de-e5ce-11e3-9652-b29017c589cc.png)
