### PR TITLE
Remove deprecated `.editor` selector

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,20 +1,20 @@
-.editor, .editor .gutter,
+atom-text-editor, atom-text-editor .gutter,
 :host, :host .gutter {
   background-color: #26292C;
   color: #F8F8F8;
 }
 
-.editor.is-focused .cursor,
+atom-text-editor.is-focused .cursor,
 :host(.is-focused) .cursor {
   border-color: #BBBCBD;
 }
 
-.editor.is-focused .selection .region,
+atom-text-editor.is-focused .selection .region,
 :host(.is-focused) .selection .region {
   background-color: #515559;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line,
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,
 :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
   background-color: #202325;
 }
@@ -347,7 +347,7 @@
   -webkit-font-smoothing: auto;
 }
 
-.editor .indent-guide,
+atom-text-editor .indent-guide,
 :host .indent-guide {
     color: lighten(#26292C, 10%);
 }


### PR DESCRIPTION
This syntax theme is still using the deprecated `.editor` selector instead of the `atom-text-editor` tag