### PR TITLE
Remove SublimeText specific selectors

### DIFF
--- a/index.less
+++ b/index.less
@@ -147,54 +147,6 @@
   background-color: #41A83E;
 }
 
-.markup.deleted.git_gutter {
-  color: #EB939A;
-}
-
-.markup.changed.git_gutter {
-  color: #72AACA;
-}
-
-.markup.inserted.git_gutter {
-  color: #B7D877;
-}
-
-.markup.ignored.git_gutter {
-  color: #798188;
-}
-
-.markup.untracked.git_gutter {
-  color: #798188;
-}
-
-.sublimelinter.outline.notes {
-  background-color: rgba(255, 255, 170, 0.31);
-}
-
-.sublimelinter.outline.illegal {
-  background-color: rgba(255, 74, 82, 0.31);
-}
-
-.sublimelinter.underline.illegal {
-  background-color: rgba(255, 0, 0, 0.31);
-}
-
-.sublimelinter.outline.warning {
-  background-color: rgba(223, 148, 0, 0.31);
-}
-
-.sublimelinter.underline.warning {
-  background-color: rgba(255, 0, 0, 0.31);
-}
-
-.sublimelinter.outline.violation {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
-.sublimelinter.underline.violation {
-  background-color: rgba(255, 0, 0, 0.31);
-}
-
 .entity.other.attribute-name.id.html {
   color: #FFB454;
 }


### PR DESCRIPTION
These selectors aren't applicable to the atom text environment.

Thanks for the theme port!