### PR TITLE
fix deprecation warnings in Atom v1.13.0

### DIFF
--- a/index.less
+++ b/index.less
@@ -15,286 +15,286 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   background-color: #202325;
 }
 
-.comment {
+.syntax--comment {
   color: #798188;
 }
 
-.string.quoted.double.block.python {
+.syntax--string.syntax--quoted.syntax--double.syntax--block.syntax--python {
   color: #798188;
 }
 
-.constant {
+.syntax--constant {
   color: #b8d977;
 }
 
-.entity {
+.syntax--entity {
   color: #72AACA;
 }
 
-.keyword {
+.syntax--keyword {
   color: #fa9a4b;
 }
 
-.storage {
+.syntax--storage {
   color: #F6F080;
 }
 
-.string {
+.syntax--string {
   color: #C4E2F2;
 }
 
-.support {
+.syntax--support {
   color: #72AACA;
 }
 
-.variable {
+.syntax--variable {
   color: #FB9A4B;
 }
 
-.invalid {
+.syntax--invalid {
   color: #F8F8F8;
-  background-color: rgba(216, 41, 13, 0.75);
+  background-color: rgba(216, 41, 13, 0.syntax--75);
 }
 
-.text .source {
-  background-color: rgba(176, 179, 186, 0.08);
+.syntax--text .syntax--source {
+  background-color: rgba(176, 179, 186, 0.syntax--08);
 }
 
-.text.html.ruby .source {
-  background-color: rgba(177, 179, 186, 0.13);
+.syntax--text.syntax--html.syntax--ruby .syntax--source {
+  background-color: rgba(177, 179, 186, 0.syntax--13);
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   color: #B7D877;
 }
 
-.string.quoted .source {
+.syntax--string.syntax--quoted .syntax--source {
   color: #B7D877;
 }
 
-.string .constant {
+.syntax--string .syntax--constant {
   color: #B7D877;
 }
 
-.string.regexp {
+.syntax--string.syntax--regexp {
   color: #FFB454;
 }
 
-.string .variable {
+.syntax--string .syntax--variable {
   color: #EDEF7D;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #FFB454;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #B7D877;
 }
 
-.other.preprocessor.c {
+.syntax--other.syntax--preprocessor.syntax--c {
   color: #8996A8;
 }
 
-.other.preprocessor.c .entity {
+.syntax--other.syntax--preprocessor.syntax--c .syntax--entity {
   color: #AFC4DB;
 }
 
-.declaration.tag, .declaration.tag .entity, .meta.tag, .meta.tag .entity {
+.syntax--declaration.syntax--tag, .syntax--declaration.syntax--tag .syntax--entity, .syntax--meta.syntax--tag, .syntax--meta.syntax--tag .syntax--entity {
   color: #B7D877;
 }
-.support.type.property-name.css {
+.syntax--support.syntax--type.syntax--property-name.syntax--css {
   color: #72AACA;
 }
 
-.meta.property-group .support.constant.property-value.css, .meta.property-value .support.constant.property-value.css {
+.syntax--meta.syntax--property-group .syntax--support.syntax--constant.syntax--property-value.syntax--css, .syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--property-value.syntax--css {
   color: #F6F080;
 }
 
-.meta.preprocessor.at-rule .keyword.control.at-rule {
+.syntax--meta.syntax--preprocessor.syntax--at-rule .syntax--keyword.syntax--control.syntax--at-rule {
   color: #F6AA11;
 }
 
-.meta.property-value .support.constant.named-color.css, .meta.property-value .constant {
+.syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--named-color.syntax--css, .syntax--meta.syntax--property-value .syntax--constant {
   color: #EDF080;
 }
 
-.meta.constructor.argument.css {
+.syntax--meta.syntax--constructor.syntax--argument.syntax--css {
   color: #EB939A;
 }
 
-.meta.diff, .meta.diff.header {
+.syntax--meta.syntax--diff, .syntax--meta.syntax--diff.syntax--header {
   color: #F8F8F8;
   background-color: #0E2231;
 }
 
-.markup.deleted {
+.syntax--markup.syntax--deleted {
   background-color: #D03620;
 }
 
-.markup.changed {
+.syntax--markup.syntax--changed {
   background-color: #C4B14A;
 }
 
-.markup.inserted {
+.syntax--markup.syntax--inserted {
   background-color: #41A83E;
 }
 
 atom-text-editor::shadow {
-  .markup.deleted.diff, .markup.changed.diff, .markup.inserted.diff {
+  .syntax--markup.syntax--deleted.syntax--diff, .syntax--markup.syntax--changed.syntax--diff, .syntax--markup.syntax--inserted.syntax--diff {
     color: #FFF;
   }
 }
 
-.entity.other.attribute-name.id.html {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--id.syntax--html {
   color: #FFB454;
 }
 
-.entity.other.attribute-name.html {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--html {
   color: #EDF080;
 }
 
-.punctuation.definition.tag.end, .punctuation.definition.tag.begin, .punctuation.definition.tag {
+.syntax--punctuation.syntax--definition.syntax--tag.syntax--end, .syntax--punctuation.syntax--definition.syntax--tag.syntax--begin, .syntax--punctuation.syntax--definition.syntax--tag {
   color: #65A4A4;
 }
 
-.keyword.control.at-rule.import.css {
+.syntax--keyword.syntax--control.syntax--at-rule.syntax--import.syntax--css {
   color: #f7f09d;
 }
 
-.variable.other.less {
+.syntax--variable.syntax--other.syntax--less {
   color: #b6d877;
 }
 
-.entity.other.less.mixin {
+.syntax--entity.syntax--other.syntax--less.syntax--mixin {
   color: #b6d877;
 }
 
-.source.css.less .keyword.unit.css {
+.syntax--source.syntax--css.syntax--less .syntax--keyword.syntax--unit.syntax--css {
   color: #EB939A;
 }
 
-.entity.other.attribute-name.angular.html, .source.angular.embedded.html {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--angular.syntax--html, .syntax--source.syntax--angular.syntax--embedded.syntax--html {
   color: #FF3A83;
 }
 
-.constant.character.entity.html {
+.syntax--constant.syntax--character.syntax--entity.syntax--html {
   color: #F1E94B;
 }
 
-.variable.other.readwrite.instance.coffee {
+.syntax--variable.syntax--other.syntax--readwrite.syntax--instance.syntax--coffee {
   color: #b6d877;
 }
 
-.meta.brace.round.coffee, .meta.brace.square.coffee {
+.syntax--meta.syntax--brace.syntax--round.syntax--coffee, .syntax--meta.syntax--brace.syntax--square.syntax--coffee {
   color: #F6F080;
 }
 
-.punctuation.section.embedded.coffee {
+.syntax--punctuation.syntax--section.syntax--embedded.syntax--coffee {
   color: #b6d877;
 }
 
-.variable.assignment.coffee .variable.assignment.coffee {
+.syntax--variable.syntax--assignment.syntax--coffee .syntax--variable.syntax--assignment.syntax--coffee {
   color: #FFFFFF;
 }
 
-.meta.delimiter.method.period.coffee {
+.syntax--meta.syntax--delimiter.syntax--method.syntax--period.syntax--coffee {
   color: #FFAA00;
 }
 
-.meta.brace.curly.coffee {
+.syntax--meta.syntax--brace.syntax--curly.syntax--coffee {
   color: #b6d877;
 }
 
-.meta.tag.sgml.doctype.xml, .declaration.sgml.html .declaration.doctype, .declaration.sgml.html .declaration.doctype .entity, .declaration.sgml.html .declaration.doctype .string, .declaration.xml-processing, .declaration.xml-processing .entity, .declaration.xml-processing .string, .doctype {
+.syntax--meta.syntax--tag.syntax--sgml.syntax--doctype.syntax--xml, .syntax--declaration.syntax--sgml.syntax--html .syntax--declaration.syntax--doctype, .syntax--declaration.syntax--sgml.syntax--html .syntax--declaration.syntax--doctype .syntax--entity, .syntax--declaration.syntax--sgml.syntax--html .syntax--declaration.syntax--doctype .syntax--string, .syntax--declaration.syntax--xml-processing, .syntax--declaration.syntax--xml-processing .syntax--entity, .syntax--declaration.syntax--xml-processing .syntax--string, .syntax--doctype {
   color: #73817D;
 }
 
-.brackethighlighter.default {
+.syntax--brackethighlighter.syntax--default {
   color: #72AACA;
 }
 
-.level-1 {
+.syntax--level-1 {
   color: #452323;
 }
 
-.level0 {
+.syntax--level0 {
   color: #234523;
 }
 
-.level1 {
+.syntax--level1 {
   color: #232345;
 }
 
-.level2 {
+.syntax--level2 {
   color: #454523;
 }
 
-.level3 {
+.syntax--level3 {
   color: #452345;
 }
 
-.level4 {
+.syntax--level4 {
   color: #234545;
 }
 
-.level5 {
+.syntax--level5 {
   color: #634141;
 }
 
-.level6 {
+.syntax--level6 {
   color: #416341;
 }
 
-.level7 {
+.syntax--level7 {
   color: #414163;
 }
 
-.level8 {
+.syntax--level8 {
   color: #636341;
 }
 
-.level9 {
+.syntax--level9 {
   color: #634163;
 }
 
-.level10 {
+.syntax--level10 {
   color: #416363;
 }
 //Improved styling for CSS
-.css .entity.name.tag, .css .entity.pseudo-class, .css .entity.punctuation.definition, .css .entity.other.attribute-name.class, .css .support.function, .css .entity.other.attribute-name.id{
+.syntax--css .syntax--entity.syntax--name.syntax--tag, .syntax--css .syntax--entity.syntax--pseudo-class, .syntax--css .syntax--entity.syntax--punctuation.syntax--definition, .syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--class, .syntax--css .syntax--support.syntax--function, .syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--id{
   color: #fa9a4b;
 }
-.css .keyword.control.operator{
+.syntax--css .syntax--keyword.syntax--control.syntax--operator{
   color: #F8F8F8;
 }
-.css .at-rule .support.function.misc{
+.syntax--css .syntax--at-rule .syntax--support.syntax--function.syntax--misc{
   color: #72AACA;
 }
-.meta.property-value .support.constant.named-color, .meta.property-value .constant{
+.syntax--meta.syntax--property-value .syntax--support.syntax--constant.syntax--named-color, .syntax--meta.syntax--property-value .syntax--constant{
   color: #b8d977;
 }
-.css .keyword.other.unit{
+.syntax--css .syntax--keyword.syntax--other.syntax--unit{
   color: #b8d977;
 }
 //Improved styling for Markdown
-.gfm{
-  .link .entity{
+.syntax--gfm{
+  .syntax--link .syntax--entity{
     color: #B7E2F2;
     font-weight: normal;
   }
-  .link .markup{
+  .syntax--link .syntax--markup{
     color: #B7D877;
     font-weight: normal;
   }
-  .heading{
+  .syntax--heading{
     color: #72AACA;
   }
-  .list{
+  .syntax--list{
     color: #B7D25D;
   }
 }
-.source .gfm{
+.syntax--source .syntax--gfm{
   -webkit-font-smoothing: auto;
 }
 

--- a/index.less
+++ b/index.less
@@ -1,21 +1,17 @@
-atom-text-editor, atom-text-editor .gutter,
-:host, :host .gutter {
+atom-text-editor, atom-text-editor .gutter {
   background-color: #26292C;
   color: #F8F8F8;
 }
 
-atom-text-editor.is-focused .cursor,
-:host(.is-focused) .cursor {
+atom-text-editor.is-focused .cursor {
   border-color: #BBBCBD;
 }
 
-atom-text-editor.is-focused .selection .region,
-:host(.is-focused) .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: #515559;
 }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,
-:host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
   background-color: #202325;
 }
 
@@ -302,8 +298,7 @@ atom-text-editor::shadow {
   -webkit-font-smoothing: auto;
 }
 
-atom-text-editor .indent-guide,
-:host .indent-guide {
+atom-text-editor .indent-guide {
     color: lighten(#26292C, 10%);
 }
 

--- a/index.less
+++ b/index.less
@@ -210,7 +210,7 @@ atom-text-editor.editor {
   color: #73817D;
 }
 
-.syntax--brackethighlighter.syntax--default {
+.brackethighlighter.syntax--default {
   color: #72AACA;
 }
 

--- a/index.less
+++ b/index.less
@@ -140,7 +140,7 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   background-color: #41A83E;
 }
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .syntax--markup.syntax--deleted.syntax--diff, .syntax--markup.syntax--changed.syntax--diff, .syntax--markup.syntax--inserted.syntax--diff {
     color: #FFF;
   }
@@ -310,11 +310,11 @@ atom-text-editor .indent-guide {
   background-color: lighten(#26292C, 10%);
 }
 
-atom-text-editor::shadow .highlight.find-result .region {
+atom-text-editor.editor .highlight.find-result .region {
   border: 1px lighten(#798188, 20%) solid;
 }
 
-atom-text-editor::shadow .highlight.current-result .region {
+atom-text-editor.editor .highlight.current-result .region {
   border: 1px #fff solid;
   background: fade(#72aaca, 50%);
 }

--- a/index.less
+++ b/index.less
@@ -53,15 +53,15 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
 
 .syntax--invalid {
   color: #F8F8F8;
-  background-color: rgba(216, 41, 13, 0.syntax--75);
+  background-color: rgba(216, 41, 13, 0.75);
 }
 
 .syntax--text .syntax--source {
-  background-color: rgba(176, 179, 186, 0.syntax--08);
+  background-color: rgba(176, 179, 186, 0.08);
 }
 
 .syntax--text.syntax--html.syntax--ruby .syntax--source {
-  background-color: rgba(177, 179, 186, 0.syntax--13);
+  background-color: rgba(177, 179, 186, 0.13);
 }
 
 .syntax--entity.syntax--other.syntax--inherited-class {


### PR DESCRIPTION
remove `:host` selector
add `syntax--` prefix to syntax related selectors
replace `::shadow` selector with `.editor`

Above changes done as suggested by Atom's Deprecation Cop.